### PR TITLE
Update path for volto-light-theme in styleguide

### DIFF
--- a/docs/docs/reference/frontend-styleguide.md
+++ b/docs/docs/reference/frontend-styleguide.md
@@ -159,6 +159,26 @@ and declare it in the root `package.json` as a dependency:
 }
 ```
 
+Also add these overrides to the root `package.json`:
+
+```json
+"pnpm": {
+  "overrides": {
+    // other overrides
+    "@kitconcept/volto-light-theme": "workspace:*",
+    "@kitconcept/volto-bm3-compat": "1.0.0-alpha.1"
+  },
+  // other pnpm packages
+}
+```
+
+After that in the `volto.config.js` add @kitconcept/volto-light-theme to the addons and the thee like this:
+
+```js
+const addons = ['volto-vlt-test-styleguide', '@kitconcept/volto-light-theme'];
+const theme = '@kitconcept/volto-light-theme';
+```
+
 in the add-on's `tsconfig.json`, declare it as a path mapping:
 
 ```json

--- a/news/+update_vlt_implementation_via_styleguide.documentation
+++ b/news/+update_vlt_implementation_via_styleguide.documentation
@@ -1,0 +1,1 @@
+Updated the instructions to install VLT via the styleguide. @TimoBroeskamp

--- a/news/+update_vlt_path.documentation
+++ b/news/+update_vlt_path.documentation
@@ -1,1 +1,0 @@
-Updated the VLT path mapping in `tsconfig.json`. @TimoBroeskamp


### PR DESCRIPTION
because volto light theme is now a monorepo it has a different folder structure then before. That's why I made these changes to go into volto-light-theme/frontend/packages/volto-light-theme/src instead of volto-light-theme/src

<!-- readthedocs-preview kitconcept.core start -->
----
📚 Documentation preview 📚: https://kitconcept.core--96.org.readthedocs.build/

<!-- readthedocs-preview kitconcept.core end -->