### PR TITLE
Improve management of dependency upgrades

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,11 @@ install:  ## Install
 	$(MAKE) backend-install
 	$(MAKE) frontend-install
 
+.PHONY: upgrade
+upgrade:  ## Upgrade dependencies
+	$(MAKE) -C "./backend/" upgrade
+	$(MAKE) -C "./frontend/" upgrade
+
 .PHONY: start
 start:  ## Start
 	@echo "Starting application"

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -66,13 +66,16 @@ config-generate:
 sync: ## Sync project dependencies
 	@echo "$(GREEN)==> Sync project dependencies$(RESET)"
 	@uv sync
-	@echo "$(GREEN)==> Force update of kitconcept.voltolighttheme$(RESET)"
-	@uv sync --upgrade-package kitconcept.voltolighttheme
 
 .PHONY: install
 install: sync config ## Install Plone and dependencies
 
 $(VENV_FOLDER): sync ## Install Plone and dependencies
+
+.PHONY: upgrade
+upgrade: ## Upgrade dependencies
+	@echo "$(GREEN)==> Force update of kitconcept.voltolighttheme$(RESET)"
+	@uv sync --upgrade-package kitconcept.voltolighttheme
 
 .PHONY: clean
 clean: ## Clean environment

--- a/backend/news/+upgrade.internal
+++ b/backend/news/+upgrade.internal
@@ -1,0 +1,1 @@
+Add separate command for upgrading backend dependencies. @davisagli

--- a/docs/docs/how-to-guides/upgrade-dependencies.md
+++ b/docs/docs/how-to-guides/upgrade-dependencies.md
@@ -2,12 +2,12 @@
 myst:
   html_meta:
     "description": "Upgrade add-on dependencies in kitconcept.core"
-    "property=og:description": "Upgrade dd-on dependencies in kitconcept.core"
-    "property=og:title": "Upgrade dd-on dependencies in kitconcept.core"
+    "property=og:description": "Upgrade add-on dependencies in kitconcept.core"
+    "property=og:title": "Upgrade add-on dependencies in kitconcept.core"
     "keywords": "kitconcept Intranet Distribution, upgrade"
 ---
 
-# How to upgrade and add-on dependency in kitconcept.core
+# How to upgrade an add-on dependency in kitconcept.core
 
 This document describes how to upgrade the version of an add-on in kitconcept.core.
 
@@ -18,7 +18,7 @@ If you haven't, please follow the instructions in the [uvx documentation](https:
 
 1. Update the add-on version on the `dependencies` key of `backend/pyproject.toml`. (example: `kitconcept.voltolighttheme>=8.0.0`)
 
-2. Run `uvx repoplone sync backend` to update the lockfile
+2. Run `make upgrade` to update the lockfile
 
 3. Create an upgrade step on `kitconcept.core:base` profile.
    We at least need a null upgrade step, so that the migration tool has a chance to upgrade all dependencies listed on `kitconcept.core.factory.LocalAddonList`.

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -43,8 +43,11 @@ install: ## Installs the add-on in a development environment
 	pnpm dlx mrs-developer missdev --no-config --fetch-https
 	pnpm i
 	make build-deps
+
+.PHONY: upgrade
+upgrade: ## Upgrade @kitconcept/volto-light-theme
 	@echo "$(GREEN)==> Update volto-light-theme to the latest version$(RESET)"
-	pnpm --filter @kitconcept/core update @kitconcept/volto-light-theme
+	pnpm update @kitconcept/volto-light-theme
 
 .PHONY: start
 start: ## Starts Volto, allowing reloading of the add-on during development

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,8 @@
   "dependencies": {
     "@plone/volto": "workspace:*",
     "@plone/registry": "workspace:*",
-    "@kitconcept/core": "workspace:*"
+    "@kitconcept/core": "workspace:*",
+    "@kitconcept/volto-light-theme": "8.0.0-alpha.16"
   },
   "devDependencies": {
     "mrs-developer": "^2.2.0"

--- a/frontend/packages/kitconcept-core/news/+vltdep.internal
+++ b/frontend/packages/kitconcept-core/news/+vltdep.internal
@@ -1,0 +1,4 @@
+Remove VLT as a direct dependency of `@kitconcept/core`.
+The specific version should be managed in a distribution instead.
+This avoids the need to release `@kitconcept/core` just to include a new release of VLT.
+@davisagli

--- a/frontend/packages/kitconcept-core/package.json
+++ b/frontend/packages/kitconcept-core/package.json
@@ -27,7 +27,6 @@
     "release-alpha": "release-it --preRelease=alpha"
   },
   "dependencies": {
-    "@kitconcept/volto-light-theme": "8.0.0-alpha.16",
     "@mbarde/volto-image-crop-widget": "^0.5.1",
     "@plone-collective/volto-authomatic": "3.0.0-alpha.6"
   },

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@kitconcept/core':
         specifier: workspace:*
         version: link:packages/kitconcept-core
+      '@kitconcept/volto-light-theme':
+        specifier: 8.0.0-alpha.16
+        version: 8.0.0-alpha.16(classnames@2.5.1)(embla-carousel@8.6.0)(lodash@4.17.21)(react-dom@18.2.0(react@18.2.0))(react-intl@3.12.1(@types/react@18.3.27)(react@18.2.0))(react-redux@8.1.2(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(redux@4.2.1))(react-router-dom@5.2.0(react@18.2.0))(react@18.2.0)
       '@plone/registry':
         specifier: workspace:*
         version: link:core/packages/registry
@@ -1319,9 +1322,6 @@ importers:
 
   packages/kitconcept-core:
     dependencies:
-      '@kitconcept/volto-light-theme':
-        specifier: 8.0.0-alpha.16
-        version: 8.0.0-alpha.16(classnames@2.5.1)(embla-carousel@8.6.0)(lodash@4.17.21)(react-dom@18.2.0(react@18.2.0))(react-intl@3.12.1(@types/react@18.3.27)(react@18.2.0))(react-redux@8.1.2(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(redux@4.2.1))(react-router-dom@5.2.0(react@18.2.0))(react@18.2.0)
       '@mbarde/volto-image-crop-widget':
         specifier: ^0.5.1
         version: 0.5.1(react@18.2.0)
@@ -9449,9 +9449,6 @@ packages:
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
-
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
@@ -13415,7 +13412,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -14455,7 +14452,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -15381,7 +15378,7 @@ snapshots:
       '@rushstack/rig-package': 0.5.2
       '@rushstack/terminal': 0.10.0(@types/node@24.10.1)
       '@rushstack/ts-command-line': 4.19.1(@types/node@24.10.1)
-      lodash: 4.17.23
+      lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.11
       semver: 7.5.4
@@ -22755,7 +22752,7 @@ snapshots:
       '@babel/generator': 7.29.1
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
-      '@babel/types': 7.29.0
+      '@babel/types': 7.20.5
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
@@ -23311,9 +23308,6 @@ snapshots:
   lodash.uniqby@4.7.0: {}
 
   lodash@4.17.21: {}
-
-  lodash@4.17.23:
-    optional: true
 
   log-symbols@4.1.0:
     dependencies:

--- a/news/+upgrade.internal
+++ b/news/+upgrade.internal
@@ -1,0 +1,1 @@
+Add command for upgrading dependencies. @davisagli


### PR DESCRIPTION
The most important change here is that the `@kitconcept/core` frontend package no longer has a direct dependency on `@kitconcept/volto-light-theme`, since it does not use it directly. This should remove the need to make a new release of it every time we update VLT. Instead the VLT version will be managed in the distributions.

I added a `make upgrade` command which updates the VLT backend and frontend for the kitconcept-core project. However that's not very important because we're not typically working in this repository's project.

For now I did not try to make `make upgrade` also take care of upgrading Plone and Volto by running the repoplone commands. We could do that, but it also requires manual creation of upgrade steps, and we have decent documentation of the current process.

<!-- readthedocs-preview kitconcept.core start -->
----
📚 Documentation preview 📚: https://kitconcept.core--103.org.readthedocs.build/

<!-- readthedocs-preview kitconcept.core end -->