### PR TITLE
Replace collective.volto.formsupport with plone.formblock (#246)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,8 @@
 {
   "eslint.workingDirectories": ["./frontend"],
-  "flake8.cwd": "${workspaceFolder}/backend",
-  "flake8.args": ["--config=pyproject.toml"],
   "ruff.organizeImports": true,
   "python.terminal.activateEnvironment": true,
+  "python.defaultInterpreterPath": "${workspaceFolder}/backend/.venv/bin/python",
   "python.testing.pytestArgs": [
     "backend/tests"
   ],

--- a/backend/news/+pytest.internal
+++ b/backend/news/+pytest.internal
@@ -1,0 +1,1 @@
+Update pytest-plone to version 1.0.0. @ericof

--- a/backend/news/246.feature
+++ b/backend/news/246.feature
@@ -1,0 +1,1 @@
+Add plone.formblock dependency and uninstall collective.volto.formsupport. @ericof

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -41,7 +41,7 @@ test = [
     "plone.restapi[test]",
     "pytest",
     "pytest-cov",
-    "pytest-plone>=1.0.0a1",
+    "pytest-plone>=1.0.0",
 ]
 
 [dependency-groups]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "plone.app.querystring==2.1.7",
     "kitconcept.voltolighttheme>=8.0.0a9",
     "collective.volto.formsupport==3.2.3",
+    "plone.formblock>=1.0.0a2",
     "collective.honeypot",
     "collective.person==1.0.0b4",
     "plone.exportimport>=2.0.0a2",

--- a/backend/src/kitconcept/core/dependencies.zcml
+++ b/backend/src/kitconcept/core/dependencies.zcml
@@ -1,11 +1,34 @@
 <configure xmlns="http://namespaces.zope.org/zope">
 
+  <include
+      package="z3c.unconfigure"
+      file="meta.zcml"
+      />
+
   <!-- List all packages you depend here -->
   <include package="plone.restapi" />
   <include package="plone.volto" />
   <include package="collective.person" />
   <include package="kitconcept.voltolighttheme" />
-  <include package="collective.volto.formsupport" />
   <include package="plonegovbr.socialmedia" />
+
+  <include package="collective.volto.formsupport" />
+
+  <!-- Unconfigure components from collective.volto.formsupport -->
+  <unconfigure>
+    <utility
+        factory="collective.volto.formsupport.datamanager.catalog.FormDataSoupCatalogFactory"
+        provides="souper.interfaces.ICatalogFactory"
+        name="form_data"
+        />
+    <adapter
+        factory="collective.volto.formsupport.restapi.services.form_data.form_data.FormData"
+        name="form-data"
+        />
+  </unconfigure>
+
+  <!-- Include the plone.formblock package -->
+  <include package="plone.formblock" />
+
 
 </configure>

--- a/backend/src/kitconcept/core/factory.py
+++ b/backend/src/kitconcept/core/factory.py
@@ -61,6 +61,8 @@ _PLONE_PACKAGES = [
     "plone.restapi",
     "plone.volto",
     "kitconcept.voltolighttheme",
+    "collective.volto.formsupport",
+    "plone.formblock",
     "plonegovbr.socialmedia",
 ]
 _PLONE_PROFILES = [
@@ -97,8 +99,10 @@ _PLONE_PROFILES = [
     "plone.volto:default",
     "kitconcept.voltolighttheme:default",
     "kitconcept.voltolighttheme:demo",
-    "collective.volto.formsupport:default",
+    "plone.formblock:default",
     "plonegovbr.socialmedia:demo",
+    # Leave it here until we remove the package
+    "collective.volto.formsupport:default",
 ]
 
 
@@ -149,9 +153,9 @@ class LocalAddonList:
         Addon(profile_id="plonetheme.barceloneta:default"),
         Addon(profile_id="kitconcept.voltolighttheme:default"),
         Addon(profile_id="collective.person:default"),
-        Addon(profile_id="collective.volto.formsupport:default"),
         Addon(profile_id="plonegovbr.socialmedia:default"),
         Addon(profile_id="kitconcept.core:dependencies"),
+        Addon(profile_id="plone.formblock:default"),
     ])
 
 

--- a/backend/src/kitconcept/core/profiles/base/metadata.xml
+++ b/backend/src/kitconcept/core/profiles/base/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>20260505001</version>
+  <version>20260619001</version>
 </metadata>

--- a/backend/src/kitconcept/core/profiles/dependencies/metadata.xml
+++ b/backend/src/kitconcept/core/profiles/dependencies/metadata.xml
@@ -8,7 +8,7 @@
     <dependency>profile-plone.volto:default</dependency>
     <dependency>profile-collective.person:default</dependency>
     <dependency>profile-kitconcept.voltolighttheme:default</dependency>
-    <dependency>profile-collective.volto.formsupport:default</dependency>
     <dependency>profile-plonegovbr.socialmedia:default</dependency>
+    <dependency>profile-plone.formblock:default</dependency>
   </dependencies>
 </metadata>

--- a/backend/src/kitconcept/core/upgrades/configure.zcml
+++ b/backend/src/kitconcept/core/upgrades/configure.zcml
@@ -12,5 +12,6 @@
   <include package=".v20260122001" />
   <include package=".v20260504001" />
   <include package=".v20260505001" />
+  <include package=".v20260619001" />
 
 </configure>

--- a/backend/src/kitconcept/core/upgrades/v20260619001/configure.zcml
+++ b/backend/src/kitconcept/core/upgrades/v20260619001/configure.zcml
@@ -1,0 +1,21 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    >
+
+  <genericsetup:upgradeSteps
+      profile="kitconcept.core:base"
+      source="20260505001"
+      destination="20260619001"
+      >
+    <genericsetup:upgradeDepends
+        title="Remove collective.volto.formsupport dependency"
+        import_profile="collective.volto.formsupport:uninstall"
+        />
+    <genericsetup:upgradeDepends
+        title="Install plone.formblock dependency"
+        import_profile="plone.formblock:default"
+        />
+  </genericsetup:upgradeSteps>
+
+</configure>

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,7 +3,6 @@ from kitconcept.core.testing import ACCEPTANCE_TESTING
 from kitconcept.core.testing import FUNCTIONAL_TESTING
 from kitconcept.core.testing import INTEGRATION_TESTING
 from pytest_plone import fixtures_factory
-from zope.component.hooks import site
 
 import pytest
 
@@ -32,18 +31,7 @@ def current_versions() -> CurrentVersions:
     from kitconcept.core import __version__
 
     return CurrentVersions(
-        base="20260505001",
+        base="20260619001",
         dependencies="1000",
         package=__version__,
     )
-
-
-@pytest.fixture(scope="class")
-def portal_class(integration_class):
-    if hasattr(integration_class, "testSetUp"):
-        integration_class.testSetUp()
-    portal = integration_class["portal"]
-    with site(portal):
-        yield portal
-    if hasattr(integration_class, "testTearDown"):
-        integration_class.testTearDown()

--- a/backend/tests/services/conftest.py
+++ b/backend/tests/services/conftest.py
@@ -1,7 +1,6 @@
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.restapi.testing import RelativeSession
-from zope.component.hooks import site
 
 import pytest
 
@@ -12,14 +11,8 @@ def portal(functional):
 
 
 @pytest.fixture(scope="class")
-def portal_class(functional_class):
-    if hasattr(functional_class, "testSetUp"):
-        functional_class.testSetUp()
-    portal = functional_class["portal"]
-    with site(portal):
-        yield portal
-    if hasattr(functional_class, "testTearDown"):
-        functional_class.testTearDown()
+def portal_class(functional_portal_class):
+    yield functional_portal_class
 
 
 @pytest.fixture()

--- a/backend/tests/setup/test_setup_install.py
+++ b/backend/tests/setup/test_setup_install.py
@@ -7,7 +7,7 @@ import pytest
 
 class TestSetupInstall:
     @pytest.fixture(autouse=True)
-    def _setup(self, current_versions):
+    def _setup(self, current_versions) -> None:
         self.profile_version: str = current_versions.base
         self.dependencies_profile_version: str = current_versions.dependencies
 
@@ -59,13 +59,23 @@ class TestSetupDependencies:
             "plone.volto:default",
             "plonetheme.barceloneta:default",
             "kitconcept.voltolighttheme:default",
-            "collective.volto.formsupport:default",
+            "plone.formblock:default",
             "plonegovbr.socialmedia:default",
         ],
     )
     def test_installed(self, profile: str):
         """Test if a profile is installed."""
         assert self.setup_tool.getLastVersionForProfile(profile) is not None
+
+    @pytest.mark.parametrize(
+        "profile",
+        [
+            "collective.volto.formsupport:default",
+        ],
+    )
+    def test_uninstalled(self, profile: str):
+        """Test if a profile is not installed."""
+        assert self.setup_tool.getLastVersionForProfile(profile) == "unknown"
 
     @pytest.mark.parametrize(
         "portal_type,title,klass",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1152,6 +1152,7 @@ dependencies = [
     { name = "plone-app-querystring" },
     { name = "plone-distribution" },
     { name = "plone-exportimport" },
+    { name = "plone-formblock" },
     { name = "products-cmfplone" },
 ]
 
@@ -1191,6 +1192,7 @@ requires-dist = [
     { name = "plone-app-testing", marker = "extra == 'test'" },
     { name = "plone-distribution" },
     { name = "plone-exportimport", specifier = ">=2.0.0a2" },
+    { name = "plone-formblock", specifier = ">=1.0.0a2" },
     { name = "plone-restapi", extras = ["test"], marker = "extra == 'test'" },
     { name = "products-cmfplone", specifier = "==6.1.4" },
     { name = "pytest", marker = "extra == 'test'" },
@@ -2859,6 +2861,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0f/a0/9f3a4eaa1e844c419092e599d2b308af965b58bef061e9203b0dc161c631/plone.folder-4.0.1.tar.gz", hash = "sha256:0082abaa129fa434f4f5841164108e3db76e19e1ede8893e2bc3b14dc4883478", size = 30876, upload-time = "2024-01-22T20:02:34.905Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/0b/83624d18a1c370a50a84890046d012d6393b851fb1648fa315d3ae5dadae/plone.folder-4.0.1-py3-none-any.whl", hash = "sha256:68886e45058190a2a005ef9247b199ee0c7f51bdefcde5c6419de8c0fe25ac5e", size = 25967, upload-time = "2024-01-22T20:02:32.756Z" },
+]
+
+[[package]]
+name = "plone-formblock"
+version = "1.0.0a2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "jsonschema" },
+    { name = "plone-api" },
+    { name = "plone-restapi" },
+    { name = "plone-volto" },
+    { name = "products-cmfplone" },
+    { name = "pyotp" },
+    { name = "souper-plone" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/2c/f184add43539b0b53ceb7857a70cd532af520b9eef28b8fa60b9da3d4e47/plone_formblock-1.0.0a2.tar.gz", hash = "sha256:059ff2452349d79a0e007c80527758d02d771baf9d22f8ab75c7bbff534a2612", size = 133651, upload-time = "2026-06-18T15:23:09.514Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/86/c310b2d0202affd415eceee62308fa3b4b3774df5a34b4b641d27d946d47/plone_formblock-1.0.0a2-py3-none-any.whl", hash = "sha256:c91288c9e1821bb556638bfb29630c2cdeb93aba309d0c3c2f59f6e2c6670c66", size = 89528, upload-time = "2026-06-18T15:23:07.894Z" },
 ]
 
 [[package]]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1195,7 +1195,7 @@ requires-dist = [
     { name = "products-cmfplone", specifier = "==6.1.4" },
     { name = "pytest", marker = "extra == 'test'" },
     { name = "pytest-cov", marker = "extra == 'test'" },
-    { name = "pytest-plone", marker = "extra == 'test'", specifier = ">=1.0.0a1" },
+    { name = "pytest-plone", marker = "extra == 'test'", specifier = ">=1.0.0" },
 ]
 provides-extras = ["test"]
 
@@ -4282,7 +4282,7 @@ wheels = [
 
 [[package]]
 name = "pytest-plone"
-version = "1.0.0a2"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "plone-api" },
@@ -4292,13 +4292,14 @@ dependencies = [
     { name = "plone-dexterity" },
     { name = "products-cmfplone", extra = ["test"] },
     { name = "pytest" },
+    { name = "requests" },
     { name = "zope-component" },
     { name = "zope-pytestlayer" },
     { name = "zope-schema" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/2e/5ff66321565851d500ce691611f9e2dae1e9260a39ccee119275f1513050/pytest_plone-1.0.0a2.tar.gz", hash = "sha256:9916ff9293463b7e83088d12dab717aa3077b685ef12915b40458d23678683e3", size = 18993, upload-time = "2025-06-11T22:29:04.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/57/3b6cac92b5554e1c7f124dcb2b8cf25bc3de63668d264fee2c43ab4240ca/pytest_plone-1.0.0.tar.gz", hash = "sha256:3c60b893edc9a1dadf2a21b090b1ca389a2787dc754105ee7b6b35721361a822", size = 28120, upload-time = "2026-05-18T22:12:42.902Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/43/386e61230fc75be1a5a49d5b9583637859ccec000fa0536ade1b59bdc360/pytest_plone-1.0.0a2-py3-none-any.whl", hash = "sha256:48c993aef530123dcaa893eeef098fcdc91a02ed89786de0743caae085a45723", size = 16253, upload-time = "2025-06-11T22:29:03.253Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a8/01780c4ded556b57e617e88e0cd0c2eb11c6f41f0f27aec3d5b3e4c1885d/pytest_plone-1.0.0-py3-none-any.whl", hash = "sha256:51533c8df40947fcf7eae865483bae6e7ac4b94481c55724846cdd86868ef058", size = 23434, upload-time = "2026-05-18T22:12:41.303Z" },
 ]
 
 [[package]]

--- a/news/+vscode.internal
+++ b/news/+vscode.internal
@@ -1,0 +1,1 @@
+Update `.vscode/settings.json`. @ericof


### PR DESCRIPTION
## Summary

Adopt [`plone.formblock`](https://github.com/plone/form-block) as the form solution for `kitconcept.core` and migrate away from `collective.volto.formsupport`.

`plone.formblock` is the upstream successor to `collective.volto.formsupport` (heading toward Plone core in 6.3), so this moves the distribution onto the supported path.

## Changes (backend)

- Add the `plone.formblock>=1.0.0a2` dependency.
- Install `plone.formblock:default` on new sites and stop installing `collective.volto.formsupport:default`.
- Unconfigure the `form_data` soup catalog utility and the `form-data` REST service from `collective.volto.formsupport` (via `z3c.unconfigure`) so they do not clash with the equivalents registered by `plone.formblock`.
- Add upgrade step `v20260619001` to uninstall `collective.volto.formsupport` and install `plone.formblock` on existing sites.
- Update the setup tests to assert `plone.formblock` is installed and `collective.volto.formsupport` is uninstalled.

> **Note:** the `collective.volto.formsupport` distribution is intentionally kept as a dependency for now, as we need to uninstall it from existing sites. It will be dropped in a follow-up once the migration has settled. Also we use the `unconfigure` directive to resolve ZCA registration classes.


## Issue

Relates to kitconcept/distribution-kitconcept-intranet#246 — https://gitlab.kitconcept.io/kitconcept/distribution-kitconcept-intranet/-/issues/246

## Test plan

- `make test` — full backend suite: **140 passed, 3 skipped**.
- `ruff` lint + format clean; `zpretty --check` clean.